### PR TITLE
Fix avatar component

### DIFF
--- a/packages/next-hr-fe/src/atoms/avatar.tsx
+++ b/packages/next-hr-fe/src/atoms/avatar.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-
 import {
   Avatar as MuiAvatar,
   AvatarProps as MuiAvatarProps,
 } from '@mui/material';
 
-export interface ProfileAvatarProps extends MuiAvatarProps {
+interface ProfileAvatarProps extends MuiAvatarProps {
   alt?: never;
   children: React.ReactNode;
   height?: never;
@@ -35,12 +34,17 @@ function Avatar({
   src,
   type,
   width = 400,
-}: AvatarProps) {
+}: AvatarProps): JSX.Element {
   const sxProps = type === 'profile' ? {} : {width, height};
   const classname = type === 'profile' ? 'profile' : '';
 
   return (
-    <MuiAvatar alt={alt} src={src} sx={sxProps} className={classname}>
+    <MuiAvatar
+      alt={alt}
+      src={type === 'profile' ? undefined : src}
+      sx={sxProps}
+      className={classname}
+    >
       {type === 'profile' ? children : null}
     </MuiAvatar>
   );

--- a/packages/next-hr-fe/src/atoms/avatar.tsx
+++ b/packages/next-hr-fe/src/atoms/avatar.tsx
@@ -4,7 +4,7 @@ import {
   AvatarProps as MuiAvatarProps,
 } from '@mui/material';
 
-interface ProfileAvatarProps extends MuiAvatarProps {
+export interface ProfileAvatarProps extends MuiAvatarProps {
   alt?: never;
   children: React.ReactNode;
   height?: never;
@@ -13,7 +13,7 @@ interface ProfileAvatarProps extends MuiAvatarProps {
   width?: never;
 }
 
-interface DefaultAvatarProps extends MuiAvatarProps {
+export interface DefaultAvatarProps extends MuiAvatarProps {
   alt: string;
   children?: never;
   height?: number;

--- a/packages/next-hr-fe/src/stories/atoms/avatar.stories.tsx
+++ b/packages/next-hr-fe/src/stories/atoms/avatar.stories.tsx
@@ -6,6 +6,13 @@ import avatarFamily from '../../assets/images/avatar-family.svg';
 import avatarFather from '../../assets/images/avatar-father.svg';
 import avatarFriends from '../../assets/images/avatar-friends.svg';
 
+const imageOptions = {
+  'Avatar Group': avatarGroup,
+  'Avatar Family': avatarFamily,
+  'Avatar Father': avatarFather,
+  'Avatar Friends': avatarFriends,
+};
+
 const meta = {
   title: 'Atoms/Avatar',
   component: Avatar,
@@ -14,9 +21,23 @@ const meta = {
     layout: 'centered',
   },
   argTypes: {
-    alt: {control: 'text'},
-    children: {control: 'text'},
-    type: {control: 'radio', options: ['profile', undefined]},
+    alt: {
+      control: 'text',
+      description: 'Alternative text for the avatar image',
+    },
+    src: {
+      control: 'radio',
+      options: Object.keys(imageOptions),
+      mapping: imageOptions,
+      if: {arg: 'type', neq: 'profile'},
+    },
+    type: {control: 'radio', options: ['profile', 'avatar']},
+    children: {
+      control: 'text',
+      description:
+        'Content inside the profile avatar, only applicable for type "profile"',
+      if: {arg: 'type', eq: 'profile'},
+    },
     width: {control: 'number'},
     height: {control: 'number'},
   },
@@ -26,17 +47,18 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-// TODO: HR-1000 Fix error with profile type
-// export const AvatarProfile: Story = {
-//   args: {
-//     type: "profile" as const,
-//     children: "MR"
-//   }
-// };
+export const DefaultAvatar: Story = {
+  args: {
+    alt: 'Default Avatar',
+    src: avatarGroup,
+    width: 400,
+    height: 400,
+  },
+};
 
 export const AvatarFriends: Story = {
   args: {
-    alt: 'avatar friends',
+    alt: 'Avatar Friends',
     src: avatarFriends,
     width: 651,
     height: 407,
@@ -45,7 +67,7 @@ export const AvatarFriends: Story = {
 
 export const AvatarGroup: Story = {
   args: {
-    alt: 'avatar group',
+    alt: 'Avatar Group',
     src: avatarGroup,
     width: 612,
     height: 347,
@@ -54,7 +76,7 @@ export const AvatarGroup: Story = {
 
 export const AvatarFamily: Story = {
   args: {
-    alt: 'avatar family',
+    alt: 'Avatar Family',
     src: avatarFamily,
     width: 592,
     height: 422,
@@ -63,7 +85,7 @@ export const AvatarFamily: Story = {
 
 export const AvatarFather: Story = {
   args: {
-    alt: 'avatar father',
+    alt: 'Avatar Father',
     src: avatarFather,
     width: 476,
     height: 476,


### PR DESCRIPTION
### Description

**Default**
When selecting avatar/default type, the src option is enabled to select the avatar, the size of the avatar is changed and children is not enabled
![image](https://github.com/user-attachments/assets/43034622-c3a8-4802-b6d7-c68f5a82a60c)
 
Example: selected 'Avatar Father'

![image](https://github.com/user-attachments/assets/eba98a04-3350-489b-a41d-bf1b34dab6dc)

**Profile**
When selecting profile type, the src option disappears, the size of the avatar is changed and it is enabled to write the text and the entered text is painted

![image](https://github.com/user-attachments/assets/6012ba1f-4069-4a10-9fd5-7a0b5c6e5e31)
